### PR TITLE
メッセージの非同期通信の実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,16 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file. JavaScript code in this file should be added after the last require_* statement.
+//
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
+//= require jquery
+//= require jquery_ujs
+//= require turbolinks
+//= require_tree .

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#new_message').on('submit',function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  })
+});

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,39 @@
 $(function(){
+  function buildMessage(message){
+    if(message.image == null){
+    var html = `<div class="message">
+                <div class="message__info">
+                <p class="message__info__user">
+                ${message.name}
+                </p>
+                <p class="message__info__date">
+                ${message.time}
+                </p>
+                </div>
+                <p class="message__text">
+                ${message.content}
+                </p>
+                </div>`
+    return html;
+    }
+    else {
+    var html = `<div class="message">
+                <div class="message__info">
+                <p class="message__info__user">
+                ${message.name}
+                </p>
+                <p class="message__info__date">
+                ${message.time}
+                </p>
+                </div>
+                <p class="message__text">
+                ${message.content}
+                </p>
+                <img class="" src="${message.image}" alt="">
+                </div>`
+                return html;
+    }}
+
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -10,6 +45,19 @@ $(function(){
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(message){
+      var html = buildMessage(message);
+      $('.main-container__messages').append(html)
+      $(window).scrollTop(300);
+      $('.input-box__text').val('')
+      $('.submit-btn').prop('disabled', false);
+      $('.main-container__messages').removeAttr('disabled');
+      $('.main-container__messages').animate({ scrollTop: $('.main-container__messages')[0].scrollHeight});
+      return false
+    })
+    .fail(function(){
+      alert('エラー');
     })
   })
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,11 +1,6 @@
 $(function(){
   function buildMessage(message){
-    if(message.image == null) {
-      var imageUrl = '';
-    }
-    else {
-      var imageUrl = `<img class="" src="${message.image}" alt="">`;
-    }
+    var imageUrl = message.image === null ? '' : `<img class="" src="${message.image}" alt="">`
     var html = `<div class="message">
                 <div class="message__info">
                 <p class="message__info__user">

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,22 +1,11 @@
 $(function(){
   function buildMessage(message){
-    if(message.image == null){
-    var html = `<div class="message">
-                <div class="message__info">
-                <p class="message__info__user">
-                ${message.name}
-                </p>
-                <p class="message__info__date">
-                ${message.time}
-                </p>
-                </div>
-                <p class="message__text">
-                ${message.content}
-                </p>
-                </div>`
-    return html;
+    if(message.image == null) {
+      var imageUrl = '';
     }
     else {
+      var imageUrl = `<img class="" src="${message.image}" alt="">`;
+    }
     var html = `<div class="message">
                 <div class="message__info">
                 <p class="message__info__user">
@@ -29,10 +18,10 @@ $(function(){
                 <p class="message__text">
                 ${message.content}
                 </p>
-                <img class="" src="${message.image}" alt="">
+                ${imageUrl}
                 </div>`
                 return html;
-    }}
+    }
 
   $('#new_message').on('submit',function(e){
     e.preventDefault();
@@ -49,8 +38,7 @@ $(function(){
     .done(function(message){
       var html = buildMessage(message);
       $('.main-container__messages').append(html)
-      $(window).scrollTop(300);
-      $('.input-box__text').val('')
+      $("form")[0].reset();
       $('.submit-btn').prop('disabled', false);
       $('.main-container__messages').removeAttr('disabled');
       $('.main-container__messages').animate({ scrollTop: $('.main-container__messages')[0].scrollHeight});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,12 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      # redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      flash.now[:notice] = 'メッセージが送信されました'
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(@group)} 
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,7 +3,7 @@
     %p.message__info__user
       = message.user.name
     %p.message__info__date
-      = message.created_at.strftime("%Y/%m/%d %H:%M")
+      = message.created_at.strftime("%Y-%m-%d %H:%M")
   %p.message__text
     - if message.content.present?
       = message.content

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,6 @@
+json.name @message.user.name
+json.content @message.content
+json.image @message.image.url
+json.group_id @message.group_id
+json.time @message.created_at.strftime("%Y-%m-%d %H:%M")
+json.user_id @message.group_id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,6 +1,4 @@
 json.name @message.user.name
 json.content @message.content
 json.image @message.image.url
-json.group_id @message.group_id
 json.time @message.created_at.strftime("%Y-%m-%d %H:%M")
-json.user_id @message.group_id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -18,7 +18,7 @@
         .input-box
           = form_for [@group, @message] do |f|
             = f.text_field :content, class: 'input-box__text', placeholder: 'type a message'
-            = f.label :image, class: 'input-box__image' do
+            = f.label :image, class: 'input-box__image', id: "upload-icon" do
               = fa_icon 'picture-o'
               = f.file_field :image, class: 'input-box__image__file'
             = f.submit 'Send', class: 'submit-btn'

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
+    # config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
# What
メッセージの送信を非同期でおこなえるようにする
以下実装済み
・イベントが発火したときにAjaxを使用して、messages#createが動くようにする
・messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
・jbuilderを使用して、作成したメッセージをJSON形式で返す
・返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
・6で作成したHTMLをメッセージ画面の一番下に追加する
・HTMLを追加した分、メッセージ画面を下にスクロールする
・連続で送信ボタンを押せるようにする
・非同期に失敗した場合の処理も準備する

実際の動作
メッセージの送信
https://gyazo.com/947b455ae4fd5588967b9ea2e29bcff7

画像とメッセージの送信
https://gyazo.com/6e5fbb31743bd9f8b1d92223f22a7791

# Why
メッセージを送信するたびに送信画面にリダイレクトしており、ビューが毎回再描画されてしまうため
