### PR TITLE
メッセージの自動更新機能実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -60,7 +60,6 @@ $(function(){
     .done(function(messages) {
       var insertHTML = '';
         messages.forEach(function(message){
-          console.log(message)
           insertHTML = buildMessage(message);
           $('.main-container__messages').append(insertHTML);
           $('.main-container__messages').animate({ scrollTop: $('.main-container__messages')[0].scrollHeight});

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,7 +1,8 @@
+$(document).on('turbolinks:load', function() {
 $(function(){
   function buildMessage(message){
     var imageUrl = message.image === null ? '' : `<img class="" src="${message.image}" alt="">`
-    var html = `<div class="message">
+    var html = `<div class="message" data-message-id="${message.id}">
                 <div class="message__info">
                 <p class="message__info__user">
                 ${message.name}
@@ -43,4 +44,36 @@ $(function(){
       alert('エラー');
     })
   })
+
+  // 以下メッセージの自動更新
+  $(function(){
+  var reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){
+    var last_message_id = $('.message:last').data('message-id'); 
+    var href = 'api/messages#index {:format=>"json"}'
+    $.ajax({
+      url: href,
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      var insertHTML = '';
+        messages.forEach(function(message){
+          console.log(message)
+          insertHTML = buildMessage(message);
+          $('.main-container__messages').append(insertHTML);
+          $('.main-container__messages').animate({ scrollTop: $('.main-container__messages')[0].scrollHeight});
+        })
+    })
+    .fail(function() {
+      alert("error");
+    });
+   };
+  };
+  
+  setInterval(reloadMessages, 5000);
+  });
+
+});
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,15 @@
+class Api::MessagesController < ApplicationController
+  def index
+  # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+  group = Group.find(params[:group_id])
+  # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+  last_message_id = params[:id].to_i
+  # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+  # includesはN+1問題対策
+  @messages = group.messages.includes(:user).where("id > #{last_message_id}") 
+  respond_to do |format|
+    format.html
+    format.json
+  end
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.time message.created_at.strftime("%Y-%m-%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{"data-message-id": "#{message.id}"}
   .message__info
     %p.message__info__user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.name @message.user.name
 json.content @message.content
 json.image @message.image.url
 json.time @message.created_at.strftime("%Y-%m-%d %H:%M")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
チャット画面が自動で更新され、自分以外のユーザーが送信したメッセージも更新時に表示されるようにした。

#Why
画面のリロードをせずに他のユーザーのメッセージを見れるようにするため
メッセージの送受信をスムーズにし、アプリケーションの機能性を向上させるため

2画面ひらき、同時に更新している様子
https://gyazo.com/8075d3737fc7fbc9aec79ec26cb591e6

別のグループの投稿に影響しない様子
https://gyazo.com/4327c53a4101202896f08d4b01c734d3